### PR TITLE
Compile comments

### DIFF
--- a/src/Skrz/Templating/Engine/Compiler.php
+++ b/src/Skrz/Templating/Engine/Compiler.php
@@ -288,7 +288,7 @@ class Compiler extends AbstractASTWalker
 
 	protected function walkComment(CommentNode $comment)
 	{
-		return "";
+		return "/* {$comment->getComment()} */";
 	}
 
 	protected function walkEcho(EchoNode $echo)

--- a/src/Skrz/Templating/Engine/Compiler.php
+++ b/src/Skrz/Templating/Engine/Compiler.php
@@ -288,7 +288,9 @@ class Compiler extends AbstractASTWalker
 
 	protected function walkComment(CommentNode $comment)
 	{
-		return "/* {$comment->getComment()} */";
+		// Do not allow nested block comments
+		$comment = strtr($comment->getComment(), ["/*" => "/ *", "*/" => "* /"]);
+		return "/* {$comment} */";
 	}
 
 	protected function walkEcho(EchoNode $echo)


### PR DESCRIPTION
Right now template comments are dropped in compilation.

So this template
```
{* Hello, I am comment *}
{$user->getTitle()}
```

results in
```php
<?php echo htmlspecialchars($user->getTitle());?>
```

For processing compiled PHP template with some 3rd party tooling it is useful to keep comments in resulting PHP file so these tools can grab them.

```php
/* Hello, I am comment */
<?php echo htmlspecialchars($user->getTitle());?>
```